### PR TITLE
Add semijoin method

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,12 @@
 Changelog
 =========
 
+v0.1.1 (2023-02-27)
+------------------------------------------------------------
+
 * Clean up documentation and switch theme (#1)
+* Add ``semijoin`` method (#2)
+* Introduce pandas accessor ``idx`` on ``DataFrame``, ``Series`` and ``Index``
 
 v0.1 (2023-02-23)
 ------------------------------------------------------------

--- a/src/pandas_indexing/__init__.py
+++ b/src/pandas_indexing/__init__.py
@@ -1,5 +1,5 @@
 """
-Pandas indexing helper
+Pandas indexing helper.
 """
 
 
@@ -14,6 +14,7 @@ from .core import (
     isin,
     ismatch,
     projectlevel,
+    semijoin,
 )
 
 


### PR DESCRIPTION
Adds `semijoin` method which filters the `DataFrame` or `Series` based on a provided `other` index or multiindex.