### PR TITLE
Fix semijoin and concat

### DIFF
--- a/src/pandas_indexing/core.py
+++ b/src/pandas_indexing/core.py
@@ -229,7 +229,9 @@ def concat(
 
         return df_or_ser.set_axis(ax.reorder_levels(order), axis=axis, copy=False)
 
-    return pd.concat([reorder(o) for o in objs], keys=keys, copy=copy, **concat_kwds)
+    return pd.concat(
+        [reorder(o) for o in objs], keys=keys, copy=copy, axis=axis, **concat_kwds
+    )
 
 
 def _notna(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -269,6 +269,8 @@ def test_concat(mdf):
         ),
     )
 
+    assert_frame_equal(concat([mdf.iloc[:, :1], mdf.iloc[:, 1:]], axis=1), mdf)
+
     with pytest.raises(ValueError):
         concat([mdf.iloc[:1], mdf.iloc[1:].droplevel("num")])
 


### PR DESCRIPTION
Fixes #22 #23 .

Re-implements semijoin to not rely on uniform types.

Adds forgotten axis passthrough in concat.