### PR TITLE
Improve semijoin and concat

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,12 @@
 Changelog
 =========
 
+* Add ``fail_on_reorder`` argument to :func:`~core.semijoin` to raise a
+  ``ValueError`` if the resulting data is not in the order of the provided
+  index (helpful in conjunction with :func:`~core.assignlevel`) :pull:`37`
+* Enhance :func:`~core.concat` to also concatenate :class:`pandas.Index` and
+  :class:`pandas.MultiIndex` objects :pull:`37`
+
 v0.2.10-b1 (2023-07-26)
 ------------------------------------------------------------
 * Revise :mod:`arithmetics` module:

--- a/src/pandas_indexing/accessors.py
+++ b/src/pandas_indexing/accessors.py
@@ -133,6 +133,7 @@ class _DataPixAccessor(_PixAccessor):
         sort: bool = False,
         axis: Axis = 0,
         fill_value: Any = no_default,
+        fail_on_reorder: bool = False,
     ) -> Union[DataFrame, Series]:
         return semijoin(
             self._obj,
@@ -142,6 +143,7 @@ class _DataPixAccessor(_PixAccessor):
             sort=sort,
             axis=axis,
             fill_value=fill_value,
+            fail_on_reorder=fail_on_reorder,
         )
 
     @doc(quantify, data="", example_call="s.pix.quantify()")

--- a/src/pandas_indexing/core.py
+++ b/src/pandas_indexing/core.py
@@ -158,13 +158,13 @@ def projectlevel(index_or_data: T, levels: Sequence[str], axis: Axis = 0) -> T:
 
 
 def concat(
-    objs: Union[Iterable[S], Mapping[str, S]],
+    objs: Union[Iterable[T], Mapping[str, T]],
     order: Optional[Sequence[str]] = None,
     axis: Axis = 0,
     keys: Union[None, str, Index, Sequence] = None,
     copy: bool = False,
     **concat_kwds,
-) -> S:
+) -> T:
     """Concatenate pandas objects along a particular axis.
 
     In addition to the functionality provided by pd.concat, if the concat axis has a multiindex
@@ -172,7 +172,7 @@ def concat(
 
     Parameters
     ----------
-    objs : a sequence or mapping of Series or DataFrame objects
+    objs : a sequence or mapping of Series, DataFrame or Index objects
         If a mapping is passed the keys will be used as a new index level
         (with the name of the `keys` argument).
     order : a sequence of str, default None
@@ -189,7 +189,7 @@ def concat(
 
     Returns
     -------
-    Concatenated data
+    Concatenated data or index
 
     Raises
     ------
@@ -219,21 +219,30 @@ def concat(
 
     orderset = frozenset(order)
 
-    def reorder(df_or_ser):
-        ax = get_axis(df_or_ser, axis=axis)
+    def reorder(df_ser_or_idx):
+        ax = get_axis(df_ser_or_idx, axis=axis)
         if ax.names == order:
-            return df_or_ser
+            return df_ser_or_idx
         elif not set(ax.names) == orderset:
             raise ValueError(
                 "All objects need to have the same index levels, but "
                 f"{set(orderset)} != {set(ax.names)}"
             )
+        idx = ax.reorder_levels(order)
+        if isinstance(df_ser_or_idx, Index):
+            return idx
 
-        return df_or_ser.set_axis(ax.reorder_levels(order), axis=axis, copy=False)
+        return df_ser_or_idx.set_axis(idx, axis=axis, copy=False)
 
-    return pd.concat(
-        [reorder(o) for o in objs], keys=keys, copy=copy, axis=axis, **concat_kwds
-    )
+    objs = [reorder(o) for o in objs]
+    if not isinstance(objs[0], Index):
+        return pd.concat(objs, keys=keys, copy=copy, axis=axis, **concat_kwds)
+
+    if keys is not None:
+        keys = Index(keys)
+        objs = [assignlevel(o, **{keys.name: k}) for o, k in zip(objs, keys)]
+
+    return reduce(lambda x, y: x.append(y), objs)
 
 
 def _notna(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -257,7 +257,7 @@ def test_extractlevel_single(midx):
         extractlevel(midx, "{e}|{typ}")
 
 
-def test_concat(mdf):
+def test_concat(mdf, midx, sidx):
     assert_frame_equal(concat([mdf.iloc[:1], mdf.iloc[1:]]), mdf)
 
     assert_frame_equal(concat([mdf.iloc[:1], None, mdf.iloc[1:].swaplevel()]), mdf)
@@ -280,6 +280,22 @@ def test_concat(mdf):
     )
 
     assert_frame_equal(concat([mdf.iloc[:, :1], mdf.iloc[:, 1:]], axis=1), mdf)
+
+    def maybe_swap(idx):
+        return idx.swaplevel() if isinstance(idx, MultiIndex) else idx
+
+    for idx in (midx, sidx):
+        assert_index_equal(concat([idx[:1], idx[1:]]), idx)
+
+        assert_index_equal(concat([idx[:1], None, maybe_swap(idx[1:])]), idx)
+
+        assert_index_equal(
+            concat(
+                {"part1": idx[:1], "part2": maybe_swap(idx[1:]), "skip": None},
+                keys="new",
+            ),
+            assignlevel(idx, new=["part1", "part2", "part2"]),
+        )
 
     with pytest.raises(ValueError):
         concat([mdf.iloc[:1], mdf.iloc[1:].droplevel("num")])


### PR DESCRIPTION
* Add `fail_on_reorder` argument to `semijoin` to raise a
  `ValueError` if the resulting data is not in the order of the provided
  index (helpful in conjunction with `assignlevel`
* Enhance `concat` to also concatenate `Index` and `MultiIndex` objects