### PR TITLE
feat(core): formatlevel and extractlevel get optional patterns

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,11 @@
 Changelog
 =========
 
+* Add support for so-called optional patterns to :func:`~core.extractlevel` and
+  :func:`~core.formatlevel`, for instance:
+  ``df.pix.extract(variable="Emissions|{gas}|{sector}", optional=["sector"])``
+  decomposes ``Emissions|CO2`` into ``{"gas": "CO2", "sector": "Total"}``.
+
 v0.5.2 (2024-08-24)
 ------------------------------------------------------------
 * Bumps minimum python version to 3.9 (which is close to EOL, anyway)

--- a/src/pandas_indexing/accessors.py
+++ b/src/pandas_indexing/accessors.py
@@ -102,9 +102,9 @@ class _PixAccessor:
 
     @doc(formatlevel, index_or_data="")
     def format(
-        self, axis: Axis = 0, **templates: str
+        self, axis: Axis = 0, optional: Sequence[str] | None = None, **templates: str
     ) -> Union[DataFrame, Series, Index]:
-        return formatlevel(self._obj, axis=axis, **templates)
+        return formatlevel(self._obj, axis=axis, optional=optional, **templates)
 
     @doc(uniquelevel, index_or_data="")
     def unique(

--- a/src/pandas_indexing/accessors.py
+++ b/src/pandas_indexing/accessors.py
@@ -80,6 +80,7 @@ class _PixAccessor:
         regex: bool = False,
         axis: Axis = 0,
         drop: Optional[bool] = None,
+        optional: Sequence[str] | None = None,
         **templates: str,
     ) -> Union[DataFrame, Series, Index]:
         if drop is not None:
@@ -95,6 +96,7 @@ class _PixAccessor:
             dropna=dropna,
             regex=regex,
             axis=axis,
+            optional=optional,
             **templates,
         )
 

--- a/src/pandas_indexing/core.py
+++ b/src/pandas_indexing/core.py
@@ -676,6 +676,8 @@ def _extractlevel(
     template: Optional[str] = None,
     keep: bool = False,
     regex: bool = False,
+    optional: frozenset[str] = frozenset(),
+    fallback: str = "Total",
     **templates: str,
 ) -> Tuple[Index, List[str]]:
     index = ensure_multiindex(index)
@@ -686,6 +688,16 @@ def _extractlevel(
             raise ValueError("``template`` may only be non-null for single index level")
         templates[index.names[0]] = template
 
+    def replace_identfier(template, ident):
+        pattern = rf"(?P<{ident}>.*?)"
+
+        if ident in optional:
+            return template.replace(rf"\|\{{{ident}\}}", rf"(?:\|{pattern})?").replace(
+                rf"\{{{ident}\}}", rf"(?:{pattern})?"
+            )
+        else:
+            return template.replace(rf"\{{{ident}\}}", pattern)
+
     for dim, template in templates.items():
         if dim not in index.names:
             raise ValueError(f"{dim} not a dimension of index: {index.names}")
@@ -695,23 +707,30 @@ def _extractlevel(
         codes = index.codes[levelnum]
 
         if regex:
-            regex_pattern = re.compile(f"^{template}$")
+            regex_pattern = re.compile(f"^{template}()$")
             identifiers = list(regex_pattern.groupindex)
         else:
             identifiers = re.findall(r"\{([a-zA-Z_]+)\}", template)
-            regex_pattern = reduce(
-                lambda s, ident: s.replace(rf"\{{{ident}\}}", rf"(?P<{ident}>.*?)"),
-                identifiers,
-                re.escape(template),
-            )
-            regex_pattern = re.compile(f"^{regex_pattern}$")
+            regex_pattern = reduce(replace_identfier, identifiers, re.escape(template))
+            regex_pattern = re.compile(f"^{regex_pattern}()$")
 
         components = labels.str.extract(regex_pattern, expand=True)
+        if optional:
+            # replace optional nans with fallback
+            match = components.iloc[:, -1].notnull()
+            components = components.assign(
+                **{
+                    ident: components[ident].where(
+                        lambda s: match & s.notnull() | ~match, fallback
+                    )
+                    for ident in optional
+                }
+            )
 
         all_identifiers.update(identifiers)
-        index = assignlevel(
-            index, **{ident: components[ident].values[codes] for ident in identifiers}
-        )
+
+        replacements = {ident: components[ident].values[codes] for ident in identifiers}
+        index = assignlevel(index, **replacements)
 
     if not keep:
         index = index.droplevel(list(set(templates) - all_identifiers))
@@ -734,15 +753,22 @@ def extractlevel(
     regex: bool = False,
     drop: Optional[bool] = None,
     axis: Axis = 0,
+    optional: Sequence[str] | None = None,
     **templates: str,
 ) -> T:
     """Extract new index levels with *templates* matched against any index
     level.
 
-    The ``**templates`` argument defines pairs of level names and templates.
-    Given level names are matched against the template, f.ex. ``"Emi|{{gas}}|{{sector}}"``.
-    Patterns (``{{gas}}`` or ``{{sector}}``) appearing in the template are extracted
-    from the successful matches and added as new levels.
+    The ``**templates`` argument defines pairs of level names and templates. Given level
+    names are matched against the template, f.ex. ``"Emi|{{gas}}|{{sector}}"``. Patterns
+    (``{{gas}}`` or ``{{sector}}``) appearing in the template are extracted from the
+    successful matches and added as new levels.
+
+    Pattern names in the ``optional`` argument can be missing (including a leading ``|``
+    character) and are replaced by the string ``"Total"`` then.
+
+    .. versionchanged:: 0.5.3
+        Added optional patterns.
 
     .. versionchanged:: 0.5.0
         *drop* replaced by *keep* and default changed to not keep.
@@ -750,20 +776,21 @@ def extractlevel(
 
     Parameters
     ----------\
-    {index_or_data}
-    template : str, optional
+    {index_or_data} template : str, optional
         Extraction template for a single level
     keep : bool, default False
         Whether to keep the split dimension
     dropna : bool, default True
         Whether to drop the non-matching levels
     regex : bool, default False
-        Whether templates are given as regular expressions
-        (regexes must use named captures)
+        Whether templates are given as regular expressions (regexes must use named
+        captures)
     axis : {{0, 1, "index", "columns"}}, default 0
         Axis of DataFrame to extract from
     drop : bool, optional
         Deprecated argument, use keep instead
+    optional : [str] or None, optional
+        Marks templates as optional
     **templates : str
         Templates for splitting one or multiple levels
 
@@ -809,6 +836,13 @@ def extractlevel(
     GWh   Elec  Coal    1
     dtype: int64
 
+    >>> extractlevel(s, variable="SE|{{type}}|{{fuel}}", optional=["fuel"])
+    unit  type  fuel
+    GWh   Elec  Bio     0
+    GWh   Elec  Coal    1
+    GWh   Elec  Total   3
+    dtype: int64
+
     >>> extractlevel(s, variable="SE|{{type}}|{{fuel}}", keep=True, dropna=False)
     variable      unit  type  fuel
     SE|Elec|Bio   GWh   Elec  Bio     0
@@ -835,6 +869,8 @@ def extractlevel(
     --------
     formatlevel
     """
+    optional = frozenset() if optional is None else frozenset(optional)
+
     if drop is not None:
         warnings.warn(
             "Argument `drop` is deprecated (use `keep` instead)", DeprecationWarning
@@ -843,11 +879,21 @@ def extractlevel(
 
     if isinstance(index_or_data, Index):
         index_or_data, identifiers = _extractlevel(
-            index_or_data, template, keep=keep, regex=regex, **templates
+            index_or_data,
+            template,
+            keep=keep,
+            regex=regex,
+            optional=optional,
+            **templates,
         )
     else:
         index, identifiers = _extractlevel(
-            get_axis(index_or_data, axis), template, keep=keep, regex=regex, **templates
+            get_axis(index_or_data, axis),
+            template,
+            keep=keep,
+            regex=regex,
+            optional=optional,
+            **templates,
         )
         index_or_data = index_or_data.set_axis(index, axis=axis)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -192,6 +192,13 @@ def test_formatlevel_options(mdf: DataFrame):
         ),
     )
 
+    # optional
+    mdf_total = assignlevel(mdf, num=["one", "two", "Total"])
+    assert_frame_equal(
+        formatlevel(mdf_total, new="{str}|{num}", drop=True, optional=["num"]),
+        mdf_total.set_axis(Index(idx_str + Index(["|one", "|two", ""]), name="new")),
+    )
+
 
 def test_formatlevel_data(mdf, mseries, midx):
     idx_str = midx.get_level_values(0)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -241,34 +241,35 @@ def test_extractlevel(mdf, mseries, midx):
     )
 
 
-def test_extractlevel_options(mdf):
+def test_extractlevel_options():
     midx = MultiIndex.from_arrays(
-        [["e|foo", "e|bar", "bar"], [1, 2, 3]], names=["var", "num"]
+        [["se|e|foo", "se|e|bar", "pe|bar", "se|e"], [1, 2, 3, 4]],
+        names=["var", "num"],
     )
-    mdf_t = mdf.T.set_axis(midx, axis=1)
+    mdf = DataFrame(dict(one=1, two=[1, 2, 3, 4], three=3, four=4), columns=midx)
 
     # keep=True
     assert_index_equal(
-        extractlevel(midx, var="{e}|{typ}", keep=True),
+        extractlevel(midx, var="se|{e}|{typ}", keep=True),
         MultiIndex.from_arrays(
-            [["e|foo", "e|bar"], [1, 2], ["e", "e"], ["foo", "bar"]],
+            [["se|e|foo", "se|e|bar"], [1, 2], ["e", "e"], ["foo", "bar"]],
             names=["var", "num", "e", "typ"],
         ),
     )
 
     # dropna=False
     assert_index_equal(
-        extractlevel(midx, var="{e}|{typ}", dropna=False),
+        extractlevel(midx, var="se|{e}|{typ}", dropna=False),
         MultiIndex.from_arrays(
-            [[1, 2, 3], ["e", "e", nan], ["foo", "bar", nan]],
+            [[1, 2, 3, 4], ["e", "e", nan, nan], ["foo", "bar", nan, nan]],
             names=["num", "e", "typ"],
         ),
     )
 
     # axis=1
     assert_frame_equal(
-        extractlevel(mdf_t, var="{e}|{typ}", axis=1),
-        mdf_t.iloc[:, [0, 1]].set_axis(
+        extractlevel(mdf, var="se|{e}|{typ}", axis=1),
+        mdf.iloc[:, [0, 1]].set_axis(
             MultiIndex.from_arrays(
                 [[1, 2], ["e", "e"], ["foo", "bar"]],
                 names=["num", "e", "typ"],
@@ -277,11 +278,29 @@ def test_extractlevel_options(mdf):
         ),
     )
 
+    # with optional
+    assert_index_equal(
+        extractlevel(midx, var="se|{e}|{typ}", optional=["typ"]),
+        MultiIndex.from_arrays(
+            [[1, 2, 4], ["e", "e", "e"], ["foo", "bar", "Total"]],
+            names=["num", "e", "typ"],
+        ),
+    )
+
+    # only optional
+    assert_index_equal(
+        extractlevel(midx, var="se|e|{typ}", optional=["typ"]),
+        MultiIndex.from_arrays(
+            [[1, 2, 4], ["foo", "bar", "Total"]],
+            names=["num", "typ"],
+        ),
+    )
+
     # regex
     assert_index_equal(
-        extractlevel(midx, var=r"((?P<e>.*?)\|)?(?P<typ>.*?)", regex=True),
+        extractlevel(midx, var=r"se\|((?P<e>.*?)\|)?(?P<typ>.*?)", regex=True),
         MultiIndex.from_arrays(
-            [[1, 2, 3], ["e", "e", nan], ["foo", "bar", "bar"]],
+            [[1, 2, 4], ["e", "e", nan], ["foo", "bar", "e"]],
             names=["num", "e", "typ"],
         ),
     )
@@ -289,16 +308,16 @@ def test_extractlevel_options(mdf):
     # drop=True
     with pytest.warns(DeprecationWarning):
         assert_index_equal(
-            extractlevel(midx, var="{e}|{typ}", drop=False),
+            extractlevel(midx, var="se|{e}|{typ}", drop=False),
             MultiIndex.from_arrays(
-                [["e|foo", "e|bar"], [1, 2], ["e", "e"], ["foo", "bar"]],
+                [["se|e|foo", "se|e|bar"], [1, 2], ["e", "e"], ["foo", "bar"]],
                 names=["var", "num", "e", "typ"],
             ),
         )
 
     with pytest.raises(ValueError):
         # mdf does not have the var level
-        extractlevel(mdf, var="{e}|{typ}")
+        extractlevel(mdf, var="se|{e}|{typ}")
 
 
 def test_extractlevel_single(midx):


### PR DESCRIPTION
To solve the common problem of extracting and formatting IAMC style variables including a common total, patterns in `formatlevel` and `extractlevel` can now be marked as optional.

```python
df.pix.extract(variable="Emi|{gas}|{sector}", optional=["sector"])
```
will now extract also `"Emi|CO2"` as `{"gas": "CO2", "sector": "Total"}`.

And the inverse of `formatlevel` behaves identically.