### PR TITLE
feat: add multiindex filtering to isin

### DIFF
--- a/src/pandas_indexing/core.py
+++ b/src/pandas_indexing/core.py
@@ -27,7 +27,6 @@ from pandas import DataFrame, Index, MultiIndex, Series
 from pandas.api.extensions import no_default
 from pandas.core.indexes.frozen import FrozenList
 
-from .selectors import isin
 from .types import Axis, Data, S, T
 from .utils import doc, get_axis, print_list, quote_list, s
 
@@ -1182,7 +1181,7 @@ def aggregatelevel(
         for level, mapping in levels.items():
             new_data.extend(
                 assignlevel(
-                    df.loc(axis=axis)[isin(**{level: old_lbls})],
+                    df.loc(axis=axis)[get_axis(df, axis).isin(old_lbls, level=level)],
                     **{level: new_lbl},
                     axis=axis,
                 )


### PR DESCRIPTION
Closes #64 .

Support passing a multiindex for filtering to `isin`.

```python
import pandas as pd
import pandas_indexing as pix

df = pd.DataFrame(
    dict(
        a=[1, 2, 3, 4, 5, 6, 7, 8, 9],
        b=[9, 8, 7, 6, 5, 4, 3, 2, 1],
        c=[4, 2, 5, 4, 6, 5, 7, 6, 8],
        d=[1, 4, 2, 5, 3, 6, 4, 7, 5],
    )
).set_index(["a", "b", "c"])
select_this_sub_levels = pd.MultiIndex.from_tuples([(8, 2), (2, 6)], names=["b", "c"])

df.loc[pix.isin(select_this_sub_levels)]
```

Can not be mixed with other filters in the same `isin` call:
```python
pix.isin(select_this_sub_levels, b=3)
```
will not build a selector, but provide a boolean mask of where `select_this_sub_levels` has `b=3` (nowhere). **Required for backward compatibility.**

It is still possible to achieve the same effect with
```python
df.loc[pix.isin(select_this_sub_levels) & pix.isin(b=3)]
```


